### PR TITLE
Handle async callables in logging decorators

### DIFF
--- a/src/api/utils.py
+++ b/src/api/utils.py
@@ -1,6 +1,7 @@
 """
 Utility functions for the House Price Prediction API.
 """
+import inspect
 import logging
 import os
 import sys
@@ -52,11 +53,32 @@ logger = setup_logging(
 
 def log_execution_time(func):
     """Decorator to log function execution time."""
+
+    if inspect.iscoroutinefunction(func):
+        @wraps(func)
+        async def async_wrapper(*args, **kwargs):
+            start_time = datetime.now()
+            logger.info(f"Starting execution of {func.__name__}")
+
+            try:
+                result = await func(*args, **kwargs)
+                execution_time = (datetime.now() - start_time).total_seconds()
+                logger.info(f"Completed {func.__name__} in {execution_time:.2f} seconds")
+                return result
+            except Exception as e:
+                execution_time = (datetime.now() - start_time).total_seconds()
+                logger.error(
+                    f"Failed {func.__name__} after {execution_time:.2f} seconds: {str(e)}"
+                )
+                raise
+
+        return async_wrapper
+
     @wraps(func)
     def wrapper(*args, **kwargs):
         start_time = datetime.now()
         logger.info(f"Starting execution of {func.__name__}")
-        
+
         try:
             result = func(*args, **kwargs)
             execution_time = (datetime.now() - start_time).total_seconds()
@@ -64,13 +86,35 @@ def log_execution_time(func):
             return result
         except Exception as e:
             execution_time = (datetime.now() - start_time).total_seconds()
-            logger.error(f"Failed {func.__name__} after {execution_time:.2f} seconds: {str(e)}")
+            logger.error(
+                f"Failed {func.__name__} after {execution_time:.2f} seconds: {str(e)}"
+            )
             raise
-    
+
     return wrapper
 
 def handle_errors(func):
     """Decorator for comprehensive error handling."""
+    if inspect.iscoroutinefunction(func):
+        @wraps(func)
+        async def async_wrapper(*args, **kwargs):
+            try:
+                return await func(*args, **kwargs)
+            except Exception as e:
+                error_details = {
+                    "function": func.__name__,
+                    "error_type": type(e).__name__,
+                    "error_message": str(e),
+                    "traceback": traceback.format_exc(),
+                    "timestamp": datetime.now().isoformat()
+                }
+                logger.error(
+                    f"Error in {func.__name__}: {json.dumps(error_details, indent=2)}"
+                )
+                raise
+
+        return async_wrapper
+
     @wraps(func)
     def wrapper(*args, **kwargs):
         try:
@@ -85,7 +129,7 @@ def handle_errors(func):
             }
             logger.error(f"Error in {func.__name__}: {json.dumps(error_details, indent=2)}")
             raise
-    
+
     return wrapper
 
 def validate_model_files(model_path: str, preprocessor_path: str) -> bool:


### PR DESCRIPTION
## Summary
- teach the execution time logger to wrap coroutine callables in an async wrapper that awaits their completion before logging results
- update the error-handling decorator to await async callables so their exceptions are logged consistently with synchronous functions

## Testing
- python - <<'PY'
import sys
from pathlib import Path
sys.path.append(str(Path('src/api').resolve()))

from unittest.mock import patch
from fastapi.testclient import TestClient

import main
from schemas import PredictionResponse

sample_request = {
    "sqft": 1500.0,
    "bedrooms": 3,
    "bathrooms": 2.0,
    "location": "suburban",
    "year_built": 2000,
    "condition": "good"
}

sample_response = PredictionResponse(
    predicted_price=200000.0,
    confidence_interval=[180000.0, 220000.0],
    features_importance={},
    prediction_time="2024-01-01T12:00:00"
)

with patch('main.predict_price', return_value=sample_response) as mock_predict, \
        patch('main.batch_predict', return_value=[200000.0, 210000.0]) as mock_batch:
    client = TestClient(main.app)

    health_resp = client.get('/health')
    print('Health:', health_resp.status_code, health_resp.json())

    predict_resp = client.post('/predict', json=sample_request)
    print('Predict:', predict_resp.status_code, predict_resp.json())
    print('predict called', mock_predict.call_count)

    batch_resp = client.post('/batch-predict', json=[sample_request, sample_request])
    print('Batch:', batch_resp.status_code, batch_resp.json())
    print('batch called', mock_batch.call_count)

PY

------
https://chatgpt.com/codex/tasks/task_e_68dde8cb6bac832292e41d0a0ae7ff13